### PR TITLE
Custom attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ $ npm install babel-plugin-remove-test-ids --save
   ]
 }
 ```
+with options
+```json
+{
+  "plugins": [
+    ['./index.js',
+      {
+        'attribute': 'data-custom-test-attr'
+      }
+    ]
+  ]
+}
+```
 
 ## Motivation
 

--- a/README.md
+++ b/README.md
@@ -28,13 +28,14 @@ $ npm install babel-plugin-remove-test-ids --save
   ]
 }
 ```
-with options
+... you can also configure it with your attributes!
 ```json
 {
   "plugins": [
-    ['./index.js',
+    [
+      "remove-test-ids",
       {
-        'attribute': 'data-custom-test-attr'
+        "attributes": ["data-test", "data-custom-test-attr"]
       }
     ]
   ]

--- a/index.js
+++ b/index.js
@@ -2,7 +2,12 @@
 
 module.exports = () => ({
   visitor: {
-    JSXAttribute: path =>
-      path.node.name.name === 'data-test-id' && path.remove()
+    JSXAttribute: (path, state) => {
+      let removeAttribute = 'data-test-id'
+      if (state.opts.attribute) {
+        removeAttribute = state.opts.attribute
+      }
+      return path.node.name.name === removeAttribute && path.remove()
+    }
   }
 })

--- a/index.js
+++ b/index.js
@@ -2,12 +2,7 @@
 
 module.exports = () => ({
   visitor: {
-    JSXAttribute: (path, state) => {
-      let removeAttribute = 'data-test-id'
-      if (state.opts.attribute) {
-        removeAttribute = state.opts.attribute
-      }
-      return path.node.name.name === removeAttribute && path.remove()
-    }
+    JSXAttribute: (path, { opts: { attributes = ['data-test-id'] }}) => 
+      attributes.includes(path.node.name.name) && path.remove()
   }
 })

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ const conf = { plugins: ['syntax-jsx', './index.js'] }
 const confWithOptions = {
   plugins: [
     'syntax-jsx',
-    ['./index.js', { attribute: 'data-custom-test-attr' }]
+    ['./index.js', { attributes: ['data-custom-test-attr'] }]
   ]
 }
 

--- a/test.js
+++ b/test.js
@@ -1,12 +1,25 @@
 const { transform } = require('babel-core')
 
 const conf = { plugins: ['syntax-jsx', './index.js'] }
+const confWithOptions = {
+  plugins: [
+    'syntax-jsx',
+    ['./index.js', { attribute: 'data-custom-test-attr' }]
+  ]
+}
 
 describe('babel-plugin-remove-test-ids', () => {
   it('should remove the [data-test-id] attribute if present', () => {
     const jsx = '<Component data-test-id="test">Hello!</Component>;'
     const expected = '<Component>Hello!</Component>;'
     const { code } = transform(jsx, conf)
+    expect(code).toEqual(expected)
+  })
+
+  it('should remove a custom test attribute', () => {
+    const jsx = '<Component data-custom-test-attr="test">Hello!</Component>;'
+    const expected = '<Component>Hello!</Component>;'
+    const { code } = transform(jsx, confWithOptions)
     expect(code).toEqual(expected)
   })
 


### PR DESCRIPTION
This is a handy plugin. I use a couple of different attrs to test that would be nice to remove, so I thought it would be a good option to pass in.

`state.opts` is always an empty object if nothing is passed in.